### PR TITLE
Replace archive2 with archive

### DIFF
--- a/conf.d/01-modules.cfg.lua
+++ b/conf.d/01-modules.cfg.lua
@@ -51,5 +51,5 @@ modules_enabled = {
 modules_disabled = {
     -- "offline"; -- Store offline messages
     -- "c2s"; -- Handle client connections
-    -- "s2s"; -- Handle server-to-server connections
+    "s2s"; -- Handle server-to-server connections
 };

--- a/conf.d/02-storage.cfg.lua
+++ b/conf.d/02-storage.cfg.lua
@@ -14,7 +14,7 @@ archive_store = "archive2" -- Use the same data store as prosody-modules mod_mam
 
 storage = {
   -- this makes mod_mam use the sql storage backend
-  archive2 = os.getenv("STORAGE");
+  archive = os.getenv("STORAGE");
 }
 
 -- https://modules.prosody.im/mod_mam.html

--- a/tests/docker-compose-tor.yml
+++ b/tests/docker-compose-tor.yml
@@ -1,0 +1,39 @@
+version: '3.7'
+
+services:
+  tor:
+    image: prosody_tor:latest #goldy/tor but compiled for armV8
+    links:
+      - prosody
+    restart: unless-stopped
+    ports:
+      - "9051:9051"
+    volumes:
+      - ./onion/:/var/lib/tor/hidden_service/
+    environment:
+      PROSODY_TOR_SERVICE_HOSTS: 5000:prosody:5000,5222:prosody:5222,5223:prosody:5223,5269:prosody:5269,5281:prosody:5281
+      TOR_SOCKS_PORT: 0.0.0.0:9051
+    hostname: tor
+  prosody:
+    build: ./prosody
+    restart: unless-stopped
+    ports:
+      - "5000:5000"
+      - "5222:5222"
+      - "5223:5223"
+      - "5269:5269"
+      - "5281:5281"
+#      - "53:53"
+    environment:
+      E2E_POLICY_CHAT: "required"
+      E2E_POLICY_MUC: "required"
+      ALLOW_REGISTRATION: "true"
+      PROSODY_ADMINS: "admin@xxx.onion"
+      DOMAIN: xxx.onion
+      STORAGE: "internal"
+      HTTP_PROXY: "socks5h://tor:9051"
+      HTTPS_PROXY: "socks5h://tor:9051"
+    volumes:
+      - ./data:/usr/local/var/lib/prosody
+      - ./certs:/usr/local/etc/prosody/certs
+    hostname: prosody


### PR DESCRIPTION
 #38  The messages aren't stored on the server as files. This is due to the use of archive2 instead of just archive as the prosody mam man page tells:

> Legacy message archive
> 
> Early versions of mod_mam (which were available in [prosody-modules](https://prosody.im/community_modules)) stored data in a store called 'archive2'. This store is now just called 'archive'.
> 
> mod_mam can be instructed to use the older store name if you still have data there.
> 
> archive_store = "archive2"; -- the old data
> storage = {
>   archive2 = "sql";
> }